### PR TITLE
投稿リストページのマージリクエスト

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,16 +153,24 @@ def post():
         return render_template('home.html', data = data)    
     else:
         return render_template('post.html')
-        
 
-
-
+# 投稿リストページ
+@app.route('/mypost')
+def mypost():
+    dbname = 'ID_pass_database.db'
+    conn = sqlite3.connect(dbname)
+    curs = conn.cursor()
+    unTmp = '\''+username+'\''
+    curs.execute('SELECT * FROM Tweet WHERE id = ' + unTmp)
+    data = curs.fetchall()
+    curs.close()
+    conn.close()
+    return render_template('mypost.html', data = data)
 
 @app.route('/index')
 def toppage():
     return render_template('index.html')
-
-
+    
 if __name__=='__main__':
     app.run(debug=True)
 

--- a/templates/mypost.html
+++ b/templates/mypost.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <div class="plate" id="title">
-        <h1><span class="title">ツイッターみたいなやつ</span></h1>
+        <h1><span class="title">投稿リスト</span></h1>
     </div>
     <header>
         <div class="side">


### PR DESCRIPTION
投稿リストページ追加に当たって他のファイルも一部変わっています。

仕組み説明
投稿リストはホームの表示を少し改変したもの。
元のSQL文に WHERE id = 'ユーザー名'を追加する。これを実現するようにpythonコードを書きました。

SQL文の例、ユーザー名がKumaである時
全ユーザーの投稿を参照
SELECT * FROM Tweet
Kumaの投稿を参照
SELECT * FROM Tweet WHERE id = 'Kuma'